### PR TITLE
Docker failed on starting container

### DIFF
--- a/dsa-server/ubuntu/Dockerfile
+++ b/dsa-server/ubuntu/Dockerfile
@@ -11,6 +11,7 @@ ENV DIST_URL ${DIST_URL}
 
 COPY run.sh /app/
 
+RUN chmod +x /app/*.sh
 RUN \
   wget ${DIST_URL} -O build.zip && \
   unzip build.zip && \


### PR DESCRIPTION
The images was created successfully, but the container when created from the image failed to start with the following error:

/usr/bin/docker-current: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"/app/run.sh\": permission denied".

Adding RUN chmod +x /app/*.sh to the dockerfile fixed the permission error